### PR TITLE
Add CROSSCFLAGS optimizations and extra instructions

### DIFF
--- a/.github/workflows/wine.yml
+++ b/.github/workflows/wine.yml
@@ -80,8 +80,9 @@ jobs:
         ./configure \
           CC='ccache gcc' \
           x86_64_CC='ccache x86_64-w64-mingw32-gcc' \
-          CFLAGS='-O3 -pipe -march=x86-64-v2' \
-          CXXFLAGS='-O3 -pipe -march=x86-64-v2' \
+          CFLAGS='-O3 -pipe -march=x86-64-v2 -mpclmul -mavx' \
+          CXXFLAGS='-O3 -pipe -march=x86-64-v2 -mpclmul -mavx' \
+          CROSSCFLAGS='-O3 -pipe -march=x86-64-v2 -mpclmul -mavx' \
           --prefix=${{ env.WINE_PREFIX }} \
           --enable-win64 \
           --host=x86_64 \


### PR DESCRIPTION
Extends 64901cf35d37267207793b480ab7424a66684843.

These instructions are safe to use. AVX for obvious reasons. The other one since all intel/amd avx cpus also have it.